### PR TITLE
Fix command injection

### DIFF
--- a/src/open.js
+++ b/src/open.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').exec
+const { execFile } = require('child_process')
 
 function _getCommand() {
     const commands = {
@@ -20,7 +20,13 @@ function open(url) {
         console.error(`Your platform ${platform} is not supported, please use other package instead`)
         return
     }
-    exec(`${command} ${url}`)
+
+    if(process.platform === 'win32') {
+        execFile('cmd', [ '/s', '/c', command, url ])
+    } else {
+        execFile(command, [ url ])
+    }
+    
 }
 
 module.exports = open


### PR DESCRIPTION
### ⚙️ Description *

I've fixed the command injection by replacing the instance of `exec` with `execFile`. This allows us to pass in the URL as an argument, which gets escaped, therefore preventing the command injection vulnerability.

### 💻 Technical Description *

Fixing this was rather trivial, but for some reason execFile wouldn't work with Windows' `start`. To fix this, I had to implement a workaround of launching an instance of `cmd` instead and then running `start` from it.

### 🐛 Proof of Concept (PoC) *

Running the following script after installing `simple-open-url` from NPM would create a file named `HACKED` in the current working directory:
```js
const open = require("simple-open-url")
open("https://huntr.dev; touch HACKED")
```

### 🔥 Proof of Fix (PoF) *

Running the PoC above on my fork will simply open a url in the browser with the url of `https://www.huntr.dev/;%20touch%20HACKED`, which proves the vulnerability has been fixed:


![image](https://user-images.githubusercontent.com/8684677/81417922-3884f100-914c-11ea-88de-58b58f8e415f.png)


### 👍 User Acceptance Testing (UAT)

To prove this hasn't broken anything, you can run the following snippet, and it should exhibit the same behaviour as with the previous versions; opening https://huntr.dev in the browser:
```js
const open = require("simple-open-url")
open("https://huntr.dev")
```